### PR TITLE
Add debug and sendStatusToUser EventTargets

### DIFF
--- a/lib/models/hub_events.dart
+++ b/lib/models/hub_events.dart
@@ -11,11 +11,13 @@ enum EventType {
 
 enum EventTarget {
   unknown,
+  debug,
   messageSent,
   receiveMessage,
   messagesRead,
   receiveSessionUpdate,
   removeSession,
+  sendStatusToUser,
   receiveStatusUpdate;
 
   factory EventTarget.parse(String? text) {


### PR DESCRIPTION
Adds 2 other hub event types to the Enum. They aren't handled or used anywhere here yet but makes the log for them a bit more clear.

```
[Hub] 21:19:05: Unhandled event received
[Hub] 21:19:05: Invocation target: debug, args:
      [[UOIYDGMA] Connected! Server uptime: 1 days 7 hours 51 minutes 12 seconds]
[Hub] 21:19:06: Unhandled event received
[Hub] 21:19:06: Invocation target: sendStatusToUser, args:
      [U-Delta]
```
Instead of just being unknown targets