### PR TITLE
[Desktop] Add back button to inventory view

### DIFF
--- a/lib/widgets/inventory/inventory_browser.dart
+++ b/lib/widgets/inventory/inventory_browser.dart
@@ -195,20 +195,17 @@ class _InventoryBrowserState extends State<InventoryBrowser> with AutomaticKeepA
                                                 appBar: AppBar(
                                                   title: Text(record.name),
                                                   leading: IconButton(
-                                                    icon: Icon(
-                                                        Icons.arrow_back),
+                                                    icon: Icon(Icons.arrow_back),
                                                     onPressed: () {
                                                       Navigator.pop(context);
                                                     },
                                                   ),
                                                 ),
-                                                body: Container(
-                                                  child: PhotoView(
+                                                body: PhotoView(
                                                   minScale: PhotoViewComputedScale.contained,
-                                                  imageProvider:
-                                                    CachedNetworkImageProvider(Aux.resdbToHttp(record.thumbnailUri)),
+                                                  imageProvider: CachedNetworkImageProvider(Aux.resdbToHttp(record.thumbnailUri)),
                                                   heroAttributes: PhotoViewHeroAttributes(tag: record.id),
-                                                )),
+                                                ),
                                               ),
                                             )
                                           );

--- a/lib/widgets/inventory/inventory_browser.dart
+++ b/lib/widgets/inventory/inventory_browser.dart
@@ -191,13 +191,26 @@ class _InventoryBrowserState extends State<InventoryBrowser> with AutomaticKeepA
                                           await Navigator.push(
                                             context,
                                             MaterialPageRoute(
-                                              builder: (context) => PhotoView(
-                                                minScale: PhotoViewComputedScale.contained,
-                                                imageProvider:
+                                              builder: (context) => Scaffold(
+                                                appBar: AppBar(
+                                                  title: Text(record.name),
+                                                  leading: IconButton(
+                                                    icon: Icon(
+                                                        Icons.arrow_back),
+                                                    onPressed: () {
+                                                      Navigator.pop(context);
+                                                    },
+                                                  ),
+                                                ),
+                                                body: Container(
+                                                  child: PhotoView(
+                                                  minScale: PhotoViewComputedScale.contained,
+                                                  imageProvider:
                                                     CachedNetworkImageProvider(Aux.resdbToHttp(record.thumbnailUri)),
-                                                heroAttributes: PhotoViewHeroAttributes(tag: record.id),
+                                                  heroAttributes: PhotoViewHeroAttributes(tag: record.id),
+                                                )),
                                               ),
-                                            ),
+                                            )
                                           );
                                         },
                                   onLongPress: () async {


### PR DESCRIPTION
Adding a back button for desktop, as desktop doesn't otherwise have the ability to trigger back like android/ios