### PR TITLE
Fix Linux build due to JSON lib version

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -44,6 +44,7 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+  target_compile_options(${TARGET} PRIVATE -Wno-deprecated)
 endfunction()
 
 # Flutter library and tool build rules.


### PR DESCRIPTION
Due to [this problem](https://github.com/juliansteenbakker/flutter_secure_storage/issues/965), the Linux build will not compile. There's a "fix" in that issue that I've applied to the `CMakeLists.txt` file in `linux` that fixes the compilation error. I say "fix" because all it does is prevent a deprecation warning from causing the build to fail.