### PR TITLE
Revert readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ A Resonite Contacts App
 
 [Get it here](https://github.com/Nutcake/ReCon/releases/latest)
 
+## Screenshots
+
+<img src="https://github.com/Nutcake/ReCon/assets/10452593/a46ccf8a-0a9f-4518-98e6-84fad2d7bf26" width=198/> <img src="https://github.com/Nutcake/ReCon/assets/10452593/5d158f58-cd27-4a68-abf3-9068e92b6a82" width=198/> <img src="https://github.com/Nutcake/ReCon/assets/10452593/f2ce95ef-e513-46cb-9654-31e74cdc7c09" width=198/> <img src="https://github.com/Nutcake/ReCon/assets/10452593/58ef5e5e-1b53-4a47-92f8-bcbcba7a1e86" width=198/>
+
 ## Building
 
-This repository solely exists to use GitHub runners to compile windows and android versions of ReCon. Check the release tab and poke me @Kodufan if there's a new update to ReCon and I need to pull upstream changes to trigger a build.
+This is a standard Flutter application, refer to the [Flutter docs](https://docs.flutter.dev/get-started/install) on how to build it.
+
+Currently only Android is fully supported.
+
+The app works on other platforms, though not every feature will be functional.
+For example, notifications are currently not supported on non-android builds.


### PR DESCRIPTION
Also moves the build instruction stuff to bottom, after the screenshots.
This was overwritten in #64 