### PR TITLE
Don't run build on PR creation

### DIFF
--- a/.github/workflows/create_release_from_builds.yml
+++ b/.github/workflows/create_release_from_builds.yml
@@ -3,8 +3,6 @@ name: CI + Create Release
 on:
   push:
     branches: [ "release" ]
-  pull_request:
-    branches: [ "release" ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
When merged, it'll run from the push commit